### PR TITLE
Wallet Login: removing onlyIfTrusted flag

### DIFF
--- a/app/components/WalletLogin.tsx
+++ b/app/components/WalletLogin.tsx
@@ -60,7 +60,7 @@ export const WalletLogin = () => {
   const loginWithPhantom = async () => {
     if (!isPhantom) return alert('Phantom not found')
     try {
-      const resp = await solana.connect({ onlyIfTrusted: true })
+      const resp = await solana.connect()
       console.log(resp.publicKey.toString(), solana.isConnected) // 26qv4GCcx98RihuK3c4T6ozB3J7L6VwCuFVc7Ta2A3Uo
       submit({
         strategy: 'phantom',


### PR DESCRIPTION
According to https://docs.phantom.app/integrating/extension-and-mobile-browser/establishing-a-connection we can only use `onlyIfTrusted` when eagerly connecting, this can be safely called on page load for new users, as they won't be bothered by a pop-up window even if they have never connected to Phantom before.